### PR TITLE
Adding `Unshareflags: syscall.CLONE_NEWNS,` fixes #3 …

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func run() {
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags: syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
+		Unshareflags: syscall.CLONE_NEWNS,
 	}
 
 	must(cmd.Run())


### PR DESCRIPTION
Adding `Unshareflags: syscall.CLONE_NEWNS,` fixes #3 by separating the mount namespace of the new process from the parent.