### PR TITLE
add bind mount, other cgroup, use pivot_root

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,15 @@ import (
 	"syscall"
 )
 
+var homePath string
+
+func init(){
+	homePath = os.Getenv("HOME")
+	if homePath == ""{
+		panic("HOME env must be specified")
+	}
+}
+
 // go run main.go run <cmd> <args>
 func main() {
 	switch os.Args[1] {
@@ -48,25 +57,61 @@ func child() {
 	cmd.Stderr = os.Stderr
 
 	must(syscall.Sethostname([]byte("container")))
-	must(syscall.Chroot("/home/liz/ubuntufs"))
+	rootPath := fmt.Sprintf("%s/ubuntufs", homePath)
+	must(syscall.Mount(rootPath, rootPath, "bind", syscall.MS_BIND, ""))
+	// bind mount
+	testBindPath := filepath.Join(rootPath, "test")
+	os.Mkdir(testBindPath, 0755)
+	must(syscall.Mount(fmt.Sprintf("%s/test", homePath), testBindPath, "", syscall.MS_BIND, ""))
+
+	// jail rootfs with pivot_root syscall
+	// ref: https://github.com/opencontainers/runc/blob/v1.0.2/libcontainer/rootfs_linux.go#L817
+	putOldPath := filepath.Join(rootPath, "put_old")
+	os.Mkdir(putOldPath, 0755)
+	must(syscall.PivotRoot(rootPath, putOldPath))
+	// lazy unmount
+	must(syscall.Unmount("/put_old", syscall.MNT_DETACH))
+	if err := os.Remove("/put_old"); err != nil{
+		panic(err)
+	}
+	//must(syscall.Chroot("fmt.Sprintf("%s/ubuntufs", homePath))
 	must(os.Chdir("/"))
 	must(syscall.Mount("proc", "proc", "proc", 0, ""))
 	must(syscall.Mount("thing", "mytemp", "tmpfs", 0, ""))
-
+ 
 	must(cmd.Run())
 
 	must(syscall.Unmount("proc", 0))
-	must(syscall.Unmount("thing", 0))
+	must(syscall.Unmount("mytemp", 0))
+	must(syscall.Unmount("/test", 0))
 }
 
 func cg() {
 	cgroups := "/sys/fs/cgroup/"
 	pids := filepath.Join(cgroups, "pids")
 	os.Mkdir(filepath.Join(pids, "liz"), 0755)
+	// Add process limition for 20
 	must(ioutil.WriteFile(filepath.Join(pids, "liz/pids.max"), []byte("20"), 0700))
 	// Removes the new cgroup in place after the container exits
 	must(ioutil.WriteFile(filepath.Join(pids, "liz/notify_on_release"), []byte("1"), 0700))
+	// Add current process in the cgroup
 	must(ioutil.WriteFile(filepath.Join(pids, "liz/cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0700))
+
+	// Add cpu limitation for 0.3 core
+	cpu := filepath.Join(cgroups, "cpu")
+	os.Mkdir(filepath.Join(cpu, "liz"), 0755)
+	must(ioutil.WriteFile(filepath.Join(cpu, "liz/cpu.cfs_period_us"), []byte("100000"), 0700))
+	must(ioutil.WriteFile(filepath.Join(cpu, "liz/cpu.cfs_quota_us"), []byte("30000"), 0700))
+	must(ioutil.WriteFile(filepath.Join(cpu, "liz/notify_on_release"), []byte("1"), 0700))
+	must(ioutil.WriteFile(filepath.Join(cpu, "liz/cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0700))
+
+	// Add memory limitation for 100M
+	mem := filepath.Join(cgroups, "memory")
+	os.Mkdir(filepath.Join(mem, "liz"), 0755)
+	must(ioutil.WriteFile(filepath.Join(mem, "liz/memory.limit_in_bytes"), []byte("100M"), 0700))
+	must(ioutil.WriteFile(filepath.Join(mem, "liz/memory.swappiness"), []byte("0"), 0700))
+	must(ioutil.WriteFile(filepath.Join(mem, "liz/notify_on_release"), []byte("1"), 0700))
+	must(ioutil.WriteFile(filepath.Join(mem, "liz/cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0700))
 }
 
 func must(err error) {


### PR DESCRIPTION
- add bind mount case
- add `cpu/memory` cgroup limitation
- use `pivot_root` replacing `chroot`