### PR TITLE
error fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,8 +40,6 @@ func run() {
 func child() {
 	fmt.Printf("Running %v \n", os.Args[2:])
 
-	cg()
-
 	cmd := exec.Command(os.Args[2], os.Args[3:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -52,6 +50,8 @@ func child() {
 	must(os.Chdir("/"))
 	must(syscall.Mount("proc", "proc", "proc", 0, ""))
 	must(syscall.Mount("thing", "mytemp", "tmpfs", 0, ""))
+	
+	cg()
 
 	must(cmd.Run())
 
@@ -62,7 +62,7 @@ func child() {
 func cg() {
 	cgroups := "/sys/fs/cgroup/"
 	pids := filepath.Join(cgroups, "pids")
-	os.Mkdir(filepath.Join(pids, "liz"), 0755)
+	os.MkdirAll(filepath.Join(pids, "liz"), 0755)
 	must(ioutil.WriteFile(filepath.Join(pids, "liz/pids.max"), []byte("20"), 0700))
 	// Removes the new cgroup in place after the container exits
 	must(ioutil.WriteFile(filepath.Join(pids, "liz/notify_on_release"), []byte("1"), 0700))


### PR DESCRIPTION
- `os.Mkdir()` does not works for the first time running the container. So I used `os.MkdirAll()` as it creates every folder in the path recursively. 
- `cg()` should be called after chroot syscall and chdir command.