### PR TITLE
cgroupsv2 adjustments

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ import (
 	"syscall"
 )
 
+var cgroups = "/sys/fs/cgroup"
+var custom_cgroup = filepath.Join(cgroups, "liz")
+
 // go run main.go run <cmd> <args>
 func main() {
 	switch os.Args[1] {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func child() {
 	// skopeo copy docker://ubuntu oci:ubuntu
 	// mkdir ubuntufs
 	// tar -xf ../ubuntu/blobs/sha256/somesha.... -C ubuntufs && rm -rf ubuntu
+	// mkdir ubuntufs/mytemp
 	must(syscall.Chroot("/tmp/containers-from-scratch/ubuntufs/"))
 	must(os.Chdir("/"))
 	must(syscall.Mount("proc", "proc", "proc", 0, ""))
@@ -62,8 +63,8 @@ func child() {
 
 	must(cmd.Run())
 
-	must(syscall.Unmount("proc", 0))
-	must(syscall.Unmount("thing", 0))
+	must(syscall.Unmount("/proc", 0))
+	must(syscall.Unmount("/mytemp", 0))
 }
 
 func cg() {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,11 @@ func child() {
 	cmd.Stderr = os.Stderr
 
 	must(syscall.Sethostname([]byte("container")))
-	must(syscall.Chroot("/home/liz/ubuntufs"))
+	// cd /tmp/containers-from-scratch
+	// skopeo copy docker://ubuntu oci:ubuntu
+	// mkdir ubuntufs
+	// tar -xf ../ubuntu/blobs/sha256/somesha.... -C ubuntufs && rm -rf ubuntu
+	must(syscall.Chroot("/tmp/containers-from-scratch/ubuntufs/"))
 	must(os.Chdir("/"))
 	must(syscall.Mount("proc", "proc", "proc", 0, ""))
 	must(syscall.Mount("thing", "mytemp", "tmpfs", 0, ""))

--- a/main.go
+++ b/main.go
@@ -70,11 +70,12 @@ func child() {
 }
 
 func cg() {
-	cgroups := "/sys/fs/cgroup/"
-	pids := filepath.Join(cgroups, "pids")
-	os.Mkdir(filepath.Join(pids, "liz"), 0755)
-	must(ioutil.WriteFile(filepath.Join(pids, "liz/pids.max"), []byte("20"), 0700))
-	must(ioutil.WriteFile(filepath.Join(pids, "liz/cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0700))
+	os.Mkdir(custom_cgroup, 0755)
+
+	must(ioutil.WriteFile(filepath.Join(custom_cgroup, "pids.max"), []byte("20"), 0644))
+	must(ioutil.WriteFile(filepath.Join(custom_cgroup, "cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0644))
+}
+
 func cgCleanup() error {
 	alive, err := ioutil.ReadFile(filepath.Join(custom_cgroup, "pids.current"))
 	if err != nil { // or must(err).. but then it'll look weird..


### PR DESCRIPTION
Makes the proof of concept work for cgroupsv2 scenarios:
.Adjust the logic in the cg(), to reflect the new cgroupsv2 hierarchy
.Adds a cgroup-cleanup mechanism that would work for cgroupsv2.
....commits should tell more

Tied to #14 
proposes solution to #10 (even though there is already one at the end of the thread)