### PR TITLE
Change unmount target from 'thing' to 'mytemp'

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func child() {
 	must(cmd.Run())
 
 	must(syscall.Unmount("proc", 0))
-	must(syscall.Unmount("thing", 0))
+	must(syscall.Unmount("mytemp", 0))
 }
 
 func cg() {


### PR DESCRIPTION
This fixes the tmpfs cleanup in child().

The tmpfs is mounted with:

    syscall.Mount("thing", "mytemp", "tmpfs", 0, "")

so it should be unmounted by passing the mount target (`mytemp`) to

syscall.Unmount, not the source (`thing`).

With the current code, Unmount("thing", 0) fails with ENOENT and causes

must() to panic after the child command exits successfully.

https://pkg.go.dev/syscall#Unmount